### PR TITLE
Add theme context with smooth toggle

### DIFF
--- a/frontend/src/app/agents/page.tsx
+++ b/frontend/src/app/agents/page.tsx
@@ -4,19 +4,9 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { AppLayout } from '@/components/layout';
-import { Button, Card, Input, Loading } from '@/components/ui';
-
-interface Agent {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  capabilities: string[];
-  model: string;
-  status: 'available' | 'coming_soon' | 'beta';
-  icon: string;
-  color: string;
-}
+import { Input, Loading, Button, Card } from '@/components/ui';
+import { AgentCard } from '@/components/agents';
+import type { Agent } from '@/types';
 
 const predefinedAgents: Agent[] = [
   {
@@ -28,7 +18,8 @@ const predefinedAgents: Agent[] = [
     model: 'GPT-4',
     status: 'available',
     icon: '🤖',
-    color: '#3b82f6'
+    color: '#3b82f6',
+    autonomous: true
   },
   {
     id: 'researcher',
@@ -39,7 +30,8 @@ const predefinedAgents: Agent[] = [
     model: 'GPT-4',
     status: 'available',
     icon: '🔬',
-    color: '#10b981'
+    color: '#10b981',
+    autonomous: true
   },
   {
     id: 'coder',
@@ -50,7 +42,8 @@ const predefinedAgents: Agent[] = [
     model: 'GPT-4',
     status: 'available',
     icon: '💻',
-    color: '#8b5cf6'
+    color: '#8b5cf6',
+    autonomous: true
   },
   {
     id: 'writer',
@@ -61,7 +54,8 @@ const predefinedAgents: Agent[] = [
     model: 'GPT-4',
     status: 'available',
     icon: '✍️',
-    color: '#f59e0b'
+    color: '#f59e0b',
+    autonomous: true
   },
   {
     id: 'analyst',
@@ -72,7 +66,8 @@ const predefinedAgents: Agent[] = [
     model: 'GPT-4',
     status: 'beta',
     icon: '📊',
-    color: '#ef4444'
+    color: '#ef4444',
+    autonomous: true
   },
   {
     id: 'designer',
@@ -83,7 +78,8 @@ const predefinedAgents: Agent[] = [
     model: 'GPT-4',
     status: 'coming_soon',
     icon: '🎨',
-    color: '#ec4899'
+    color: '#ec4899',
+    autonomous: false
   }
 ];
 
@@ -155,14 +151,6 @@ const AgentsPage: React.FC = () => {
     }
   };
 
-  const getStatusBadge = (status: Agent['status']) => {
-    const badges = {
-      available: { text: 'Available', color: 'bg-green-500/20 text-green-400 border-green-500/30' },
-      beta: { text: 'Beta', color: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30' },
-      coming_soon: { text: 'Coming Soon', color: 'bg-gray-500/20 text-gray-400 border-gray-500/30' }
-    };
-    return badges[status];
-  };
 
   // Get unique categories for filter
   const categories = Array.from(new Set(agents.map(agent => agent.category)));
@@ -212,84 +200,14 @@ const AgentsPage: React.FC = () => {
         {/* Agents Grid */}
         {filteredAgents.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredAgents.map((agent, index) => {
-              const statusBadge = getStatusBadge(agent.status);
-              
-              return (
-                <Card 
-                  key={agent.id}
-                  variant="glass" 
-                  hover={agent.status !== 'coming_soon'}
-                  className={`
-                    animate-fade-in-up stagger-${Math.min(index + 1, 6)}
-                    ${agent.status !== 'coming_soon' ? 'cursor-pointer' : 'opacity-75'}
-                  `}
-                  onClick={() => handleAgentSelect(agent)}
-                >
-                  <div className="p-6">
-                    {/* Header */}
-                    <div className="flex items-start justify-between mb-4">
-                      <div className="flex items-center gap-3">
-                        <div 
-                          className="w-12 h-12 rounded-lg flex items-center justify-center text-2xl"
-                          style={{ backgroundColor: `${agent.color}20`, border: `1px solid ${agent.color}40` }}
-                        >
-                          {agent.icon}
-                        </div>
-                        <div>
-                          <h3 className="text-heading-lg text-[var(--text-primary)] mb-1">
-                            {agent.name}
-                          </h3>
-                          <span className="text-xs text-[var(--text-muted)]">
-                            {agent.model}
-                          </span>
-                        </div>
-                      </div>
-                      
-                      <span className={`px-2 py-1 rounded-md text-xs border ${statusBadge.color}`}>
-                        {statusBadge.text}
-                      </span>
-                    </div>
-
-                    {/* Description */}
-                    <p className="text-body-sm text-[var(--text-secondary)] mb-4">
-                      {agent.description}
-                    </p>
-
-                    {/* Capabilities */}
-                    <div className="space-y-2">
-                      <h4 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
-                        Capabilities
-                      </h4>
-                      <div className="flex flex-wrap gap-2">
-                        {agent.capabilities.map(capability => (
-                          <span 
-                            key={capability}
-                            className="px-2 py-1 bg-[var(--bg-tertiary)] text-[var(--text-secondary)] text-xs rounded-md border border-[var(--border-secondary)]"
-                          >
-                            {capability}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-
-                    {/* Action */}
-                    {agent.status !== 'coming_soon' && (
-                      <div className="mt-4 pt-4 border-t border-[var(--border-secondary)]">
-                        <Button
-                          variant={agent.status === 'beta' ? 'secondary' : 'primary'}
-                          size="sm"
-                          className="w-full"
-                          onClick={() => handleAgentSelect(agent)}
-                        >
-                          {agent.status === 'beta' ? 'Try Beta' : 'Start Chat'}
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                </Card>
-              );
-            })}
+            {filteredAgents.map((agent, index) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                onSelect={handleAgentSelect}
+                className={`animate-fade-in-up stagger-${Math.min(index + 1, 6)}`}
+              />
+            ))}
           </div>
         ) : (
           <Card variant="glass" className="text-center p-12">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8,6 +8,14 @@
 /* Import Enhanced Design System */
 @import '../styles/design-system.css';
 
+/* Smooth theme transition */
+.theme-transition,
+.theme-transition * {
+  transition: background-color var(--duration-300) var(--ease-in-out),
+    color var(--duration-300) var(--ease-in-out),
+    border-color var(--duration-300) var(--ease-in-out);
+}
+
 @layer base {
   html {
     scroll-behavior: smooth;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 
 export const metadata = {
   title: 'Nova AI - Next-generation AI Chat Interface',
@@ -21,13 +22,15 @@ export default function RootLayout({
         <div className="floating-orb" />
         <div className="floating-orb" />
         
-        <ToastProvider>
-          <AuthProvider>
-            <div id="root" className="h-full relative z-10">
-              {children}
-            </div>
-          </AuthProvider>
-        </ToastProvider>
+        <ThemeProvider>
+          <ToastProvider>
+            <AuthProvider>
+              <div id="root" className="h-full relative z-10">
+                {children}
+              </div>
+            </AuthProvider>
+          </ToastProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/agents/AgentCard/AgentCard.module.css
+++ b/frontend/src/components/agents/AgentCard/AgentCard.module.css
@@ -1,0 +1,79 @@
+.agentCard {
+  position: relative;
+}
+
+.inner {
+  padding: var(--space-6);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-4);
+}
+
+.iconContainer {
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--radius-lg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid;
+}
+
+.icon {
+  font-size: 1.5rem;
+}
+
+.info {
+  flex: 1;
+  margin-left: var(--space-3);
+}
+
+.name {
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.model {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.badge {
+  font-size: var(--text-xs);
+  padding: 2px 6px;
+  border-radius: var(--radius-md);
+  border-width: 1px;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-4);
+}
+
+.capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.capability {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-secondary);
+  padding: 2px 6px;
+  border-radius: var(--radius-md);
+}
+
+.action {
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-secondary);
+}

--- a/frontend/src/components/agents/AgentCard/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard/AgentCard.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React from 'react';
+import { Agent } from '@/types';
+import { Card, Button } from '@/components/ui';
+import styles from './AgentCard.module.css';
+
+export interface AgentCardProps {
+  agent: Agent;
+  onSelect?: (agent: Agent) => void;
+  className?: string;
+}
+
+const AgentCard: React.FC<AgentCardProps> = ({ agent, onSelect, className = '' }) => {
+  const statusBadge = {
+    available: { text: 'Available', color: 'bg-green-500/20 text-green-400 border-green-500/30' },
+    beta: { text: 'Beta', color: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30' },
+    coming_soon: { text: 'Coming Soon', color: 'bg-gray-500/20 text-gray-400 border-gray-500/30' },
+  }[agent.status];
+
+  const handleSelect = () => {
+    if (agent.status !== 'coming_soon') {
+      onSelect?.(agent);
+    }
+  };
+
+  return (
+    <Card
+      variant="glass"
+      hover={agent.status !== 'coming_soon'}
+      className={`${styles.agentCard} ${className}`}
+      onClick={handleSelect}
+    >
+      <div className={styles.inner}>
+        <div className={styles.header}>
+          <div
+            className={styles.iconContainer}
+            style={{ backgroundColor: `${agent.color}20`, borderColor: `${agent.color}40` }}
+          >
+            <span className={styles.icon}>{agent.icon}</span>
+          </div>
+          <div className={styles.info}>
+            <h3 className={styles.name}>{agent.name}</h3>
+            <span className={styles.model}>{agent.model}</span>
+          </div>
+          <span className={`${styles.badge} ${statusBadge.color}`}>{statusBadge.text}</span>
+        </div>
+        <p className={styles.description}>{agent.description}</p>
+        <div className={styles.capabilities}>
+          {agent.capabilities.map(cap => (
+            <span key={cap} className={styles.capability}>
+              {cap}
+            </span>
+          ))}
+        </div>
+        {agent.status !== 'coming_soon' && (
+          <div className={styles.action}>
+            <Button
+              variant={agent.status === 'beta' ? 'secondary' : 'primary'}
+              size="sm"
+              className="w-full"
+              onClick={e => {
+                e.stopPropagation();
+                handleSelect();
+              }}
+            >
+              {agent.status === 'beta' ? 'Try Beta' : 'Start Chat'}
+            </Button>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export default AgentCard;

--- a/frontend/src/components/agents/AgentCard/index.ts
+++ b/frontend/src/components/agents/AgentCard/index.ts
@@ -1,0 +1,2 @@
+export { default as AgentCard } from './AgentCard';
+export type { AgentCardProps } from './AgentCard';

--- a/frontend/src/components/agents/index.ts
+++ b/frontend/src/components/agents/index.ts
@@ -1,0 +1,1 @@
+export * from './AgentCard';

--- a/frontend/src/components/chat/ChatInterface/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface/ChatInterface.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { ChatMessage, ChatCompletionRequest } from '@/types';
 import { MessageBubble } from '../MessageBubble';

--- a/frontend/src/components/chat/InputArea/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea/InputArea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Button } from '@/components/ui';
 import styles from './InputArea.module.css';

--- a/frontend/src/components/chat/MessageBubble/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble/MessageBubble.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import { ChatMessage } from '@/types';
 import styles from './MessageBubble.module.css';

--- a/frontend/src/components/layout/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Sidebar, Header } from '@/components/layout';
+import { useTheme } from '@/contexts/ThemeContext';
 import styles from './AppLayout.module.css';
 
 export interface AppLayoutProps {
@@ -54,11 +55,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
     }
   };
 
+  const { toggleTheme } = useTheme();
+
   const handleThemeToggle = () => {
-    const currentTheme = document.documentElement.getAttribute('data-theme');
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-theme', newTheme);
-    localStorage.setItem('theme', newTheme);
+    toggleTheme();
   };
 
   const handleSearch = (query: string) => {

--- a/frontend/src/components/layout/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout/AppLayout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect } from 'react';
 import { Sidebar, Header } from '@/components/layout';
 import { useTheme } from '@/contexts/ThemeContext';

--- a/frontend/src/components/layout/Header/Header.module.css
+++ b/frontend/src/components/layout/Header/Header.module.css
@@ -195,6 +195,11 @@
 .themeIcon {
   width: 20px;
   height: 20px;
+  transition: transform var(--duration-300) var(--ease-out);
+}
+
+.rotate {
+  transform: rotate(180deg);
 }
 
 .notificationContainer {

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useRef, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
 import styles from './Header.module.css';
 
 export interface HeaderProps {
@@ -26,6 +27,7 @@ export const Header: React.FC<HeaderProps> = ({
   onNotificationClick,
 }) => {
   const { user } = useAuth();
+  const { theme, toggleTheme } = useTheme();
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
@@ -132,18 +134,41 @@ export const Header: React.FC<HeaderProps> = ({
         {showThemeToggle && (
           <button
             className={styles.actionButton}
-            onClick={onThemeToggle}
+            onClick={() => {
+              toggleTheme();
+              onThemeToggle?.();
+            }}
             aria-label="Toggle theme"
           >
-            <svg className={styles.themeIcon} viewBox="0 0 24 24" fill="none">
-              <path
-                d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            {theme === 'dark' ? (
+              <svg
+                className={`${styles.themeIcon}`}
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <path
+                  d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            ) : (
+              <svg
+                className={`${styles.themeIcon} ${styles.rotate}`}
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <path
+                  d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            )}
           </button>
         )}
 

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';

--- a/frontend/src/components/projects/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard/ProjectCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import { Project } from '@/types';
 import { Card } from '@/components/ui';

--- a/frontend/src/components/ui/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/ui/FileUpload/FileUpload.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useRef, useCallback } from 'react';
 import { Button } from '../Button';
 import { Loading } from '../Loading';

--- a/frontend/src/components/ui/Input/Input.tsx
+++ b/frontend/src/components/ui/Input/Input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, useState } from 'react';
 import { InputProps } from '@/types';
 import styles from './Input.module.css';

--- a/frontend/src/components/ui/Modal/Modal.tsx
+++ b/frontend/src/components/ui/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styles from './Modal.module.css';

--- a/frontend/src/components/ui/Toast/Toast.tsx
+++ b/frontend/src/components/ui/Toast/Toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styles from './Toast.module.css';

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<ThemeMode>('dark');
+
+  useEffect(() => {
+    const stored = (typeof window !== 'undefined' ? localStorage.getItem('theme') : null) as ThemeMode | null;
+    const preferred = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const initial = stored || preferred;
+    setTheme(initial);
+    document.documentElement.setAttribute('data-theme', initial);
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme: ThemeMode = theme === 'dark' ? 'light' : 'dark';
+    document.documentElement.classList.add('theme-transition');
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+    setTheme(newTheme);
+    window.setTimeout(() => {
+      document.documentElement.classList.remove('theme-transition');
+    }, 300);
+  };
+
+  const value: ThemeContextType = { theme, toggleTheme };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+export default ThemeContext;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,6 +68,20 @@ export interface ProjectUpdate {
   tags?: string[];
 }
 
+// Agent types
+export interface Agent {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  capabilities: string[];
+  model: string;
+  status: 'available' | 'coming_soon' | 'beta';
+  icon: string;
+  color: string;
+  autonomous?: boolean;
+}
+
 // Chat types
 export interface ChatSession {
   id: string;


### PR DESCRIPTION
## Summary
- introduce `ThemeContext` to manage dark/light mode
- wrap app with `ThemeProvider`
- use animated icon in header for theme toggling
- smooth transition between themes via global CSS

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: many missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b58a0d0832fa1b660bb8544e5cc